### PR TITLE
This change allows the use of "__con" as a short form for the "__cons…

### DIFF
--- a/Zend/tests/__con_is_constructor.phpt
+++ b/Zend/tests/__con_is_constructor.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test that __con is treated as a constructor
+--FILE--
+<?php
+class MyClass {
+	public function __con() {
+		echo "Constructor called\n";
+	}
+}
+
+$obj = new MyClass;
+?>
+--EXPECT--
+Constructor called

--- a/Zend/zend_compile.c
+++ b/Zend/zend_compile.c
@@ -5281,7 +5281,8 @@ static void zend_compile_method_call(znode *result, zend_ast *ast, uint32_t type
 
 static bool zend_is_constructor(zend_string *name) /* {{{ */
 {
-	return zend_string_equals_literal_ci(name, ZEND_CONSTRUCTOR_FUNC_NAME);
+	return zend_string_equals_literal_ci(name, ZEND_CONSTRUCTOR_FUNC_NAME) ||
+		zend_string_equals_literal_ci(name, "__con");
 }
 /* }}} */
 


### PR DESCRIPTION
…truct" magic method.

The `zend_is_constructor` function in `Zend/zend_compile.c` has been updated to recognize both "__construct" and "__con".

A new test case has been added to verify that "__con" is correctly treated as a constructor.